### PR TITLE
Update netlify.toml to redirect all subdomains to esy.netlify.app

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [[redirects]]
   from = "https://*.esy.com/*"
-  to = "https://www.esy.com/:splat"
+  to = "https://esy.netlify.app/:splat"
   status = 301
   force = true
 
@@ -12,7 +12,7 @@
 [[headers]]
   for = "/*"
   [headers.values]
-    Content-Security-Policy = "frame-ancestors 'self' https://www.esy.com;"
+    Content-Security-Policy = "frame-ancestors 'self' https://esy.netlify.app;"
 
 [build]
   command = "npm install && npm run build"


### PR DESCRIPTION
- Changed wildcard subdomain redirect to point to esy.netlify.app.
- Ensured root domain redirects to index.html for GatsbyJS SPA.
- Updated security headers to reflect esy.netlify.app.
- Verified build command and environment settings for production.